### PR TITLE
Update to 1.4.1-preview; improve type conversion & tests

### DIFF
--- a/src/Linger.AspNetCore.Jwt.Contracts/Linger.AspNetCore.Jwt.Contracts.csproj
+++ b/src/Linger.AspNetCore.Jwt.Contracts/Linger.AspNetCore.Jwt.Contracts.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net9.0;net8.0;</TargetFrameworks>
-        <Version>1.4.0</Version>
+        <Version>1.4.1-preview</Version>
 <Description>
             Core JWT (JSON Web Token) contracts and interfaces for ASP.NET Core applications.
             Provides abstractions for token generation, validation, and refresh operations

--- a/src/Linger.AspNetCore.Jwt/Linger.AspNetCore.Jwt.csproj
+++ b/src/Linger.AspNetCore.Jwt/Linger.AspNetCore.Jwt.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net9.0;net8.0;</TargetFrameworks>
-        <Version>1.4.0</Version>
+        <Version>1.4.1-preview</Version>
         <Description>
             A comprehensive JWT authentication implementation for ASP.NET Core applications.
             Provides JWT token generation, validation, and refresh token functionality with 

--- a/src/Linger.Audit/Linger.Audit.csproj
+++ b/src/Linger.Audit/Linger.Audit.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.0</TargetFrameworks>
-        <Version>1.4.0</Version>
+        <Version>1.4.1-preview</Version>
         <Description>
             A lightweight .NET auditing library that provides base classes and interfaces for entity auditing.
             Includes audit trail tracking for creation, modification, and deletion events with built-in timestamps and user tracking.

--- a/src/Linger.Background/Linger.Background.csproj
+++ b/src/Linger.Background/Linger.Background.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
-        <Version>1.4.0</Version>        
+        <Version>1.4.1-preview</Version>        
 </PropertyGroup>
   
   <ItemGroup>

--- a/src/Linger.Configuration/Linger.Configuration.csproj
+++ b/src/Linger.Configuration/Linger.Configuration.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.0</TargetFrameworks>
-        <Version>1.4.0</Version>
+        <Version>1.4.1-preview</Version>
         <Description>
             A lightweight configuration helper library for .NET applications.
             Simplifies access to application settings with strongly-typed configuration binding.

--- a/src/Linger.Dapper.Oracle/Linger.Dapper.Oracle.csproj
+++ b/src/Linger.Dapper.Oracle/Linger.Dapper.Oracle.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
       <TargetFrameworks>net10.0;net9.0;net8.0;net472;</TargetFrameworks>
-      <Version>1.4.0</Version>
+      <Version>1.4.1-preview</Version>
 </PropertyGroup>
 
     <ItemGroup>

--- a/src/Linger.Dapper.SqlServer/Linger.Dapper.SqlServer.csproj
+++ b/src/Linger.Dapper.SqlServer/Linger.Dapper.SqlServer.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
       <TargetFrameworks>net10.0;net9.0;net8.0;net472;</TargetFrameworks>
-      <Version>1.4.0</Version>
+      <Version>1.4.1-preview</Version>
 </PropertyGroup>
 
     <ItemGroup>

--- a/src/Linger.Dapper.Sqlite/Linger.Dapper.Sqlite.csproj
+++ b/src/Linger.Dapper.Sqlite/Linger.Dapper.Sqlite.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
       <TargetFrameworks>net10.0;net9.0;net8.0;net472;</TargetFrameworks>
-            <Version>1.4.0</Version>
+            <Version>1.4.1-preview</Version>
 </PropertyGroup>
 
     <ItemGroup>

--- a/src/Linger.Dapper/Linger.Dapper.csproj
+++ b/src/Linger.Dapper/Linger.Dapper.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0;net472;</TargetFrameworks>
-    <Version>1.4.0</Version>
+    <Version>1.4.1-preview</Version>
 </PropertyGroup>
 
   <ItemGroup>

--- a/src/Linger.DataAccess.Oracle/Linger.DataAccess.Oracle.csproj
+++ b/src/Linger.DataAccess.Oracle/Linger.DataAccess.Oracle.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0;net472</TargetFrameworks>
-        <Version>1.4.0</Version>
+        <Version>1.4.1-preview</Version>
 </PropertyGroup>
 
     <ItemGroup>

--- a/src/Linger.DataAccess.SqlServer/Linger.DataAccess.SqlServer.csproj
+++ b/src/Linger.DataAccess.SqlServer/Linger.DataAccess.SqlServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0;net472</TargetFrameworks>
-        <Version>1.4.0</Version>
+        <Version>1.4.1-preview</Version>
 </PropertyGroup>
 
     <ItemGroup>

--- a/src/Linger.DataAccess.Sqlite/Linger.DataAccess.Sqlite.csproj
+++ b/src/Linger.DataAccess.Sqlite/Linger.DataAccess.Sqlite.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0;net472</TargetFrameworks>
-        <Version>1.4.0</Version>
+        <Version>1.4.1-preview</Version>
 </PropertyGroup>
 
     <ItemGroup>

--- a/src/Linger.DataAccess/Linger.DataAccess.csproj
+++ b/src/Linger.DataAccess/Linger.DataAccess.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0;net472</TargetFrameworks>
-        <Version>1.4.0</Version>
+        <Version>1.4.1-preview</Version>
 </PropertyGroup>
 
     <ItemGroup>

--- a/src/Linger.EFCore.Audit/Linger.EFCore.Audit.csproj
+++ b/src/Linger.EFCore.Audit/Linger.EFCore.Audit.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net9.0;net8.0;</TargetFrameworks>
-        <Version>1.4.0</Version>
+        <Version>1.4.1-preview</Version>
         <Description>
             An Entity Framework Core audit trail library for automatically tracking data changes.
             Captures entity creation, modification, and deletion events with old and new values.

--- a/src/Linger.EFCore/Linger.EFCore.csproj
+++ b/src/Linger.EFCore/Linger.EFCore.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net9.0;net8.0;</TargetFrameworks>
-        <Version>1.4.0</Version>
+        <Version>1.4.1-preview</Version>
         <Description>
             An Entity Framework Core extension library providing enhanced capabilities.
             Includes global query filters, property conversions for complex types, and pagination utilities.

--- a/src/Linger.Email.AspNetCore/Linger.Email.AspNetCore.csproj
+++ b/src/Linger.Email.AspNetCore/Linger.Email.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net9.0;net8.0;</TargetFrameworks>
-        <Version>1.4.0</Version>
+        <Version>1.4.1-preview</Version>
         <Description>
             ASP.NET Core integration for Linger.Email.
             Provides dependency injection, configuration binding, logging, and convenience email service wrappers.

--- a/src/Linger.Email/Linger.Email.csproj
+++ b/src/Linger.Email/Linger.Email.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">    
     <PropertyGroup>
         <TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.0</TargetFrameworks>
-        <Version>1.4.0</Version>
+        <Version>1.4.1-preview</Version>
         <Description>
             Framework-agnostic email sending library built on MailKit.
             Provides SMTP transport, message composition, attachment handling, and asynchronous sending across multiple .NET frameworks.

--- a/src/Linger.Excel.ClosedXML/Linger.Excel.ClosedXML.csproj
+++ b/src/Linger.Excel.ClosedXML/Linger.Excel.ClosedXML.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
       <TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.0;net472</TargetFrameworks>
-      <Version>1.4.0</Version>
+      <Version>1.4.1-preview</Version>
       <Description>
           Excel operations implementation based on ClosedXML library for the Linger.Excel framework.
           Provides high-performance Excel file reading, writing, styling, and manipulation

--- a/src/Linger.Excel.Contracts/Linger.Excel.Contracts.csproj
+++ b/src/Linger.Excel.Contracts/Linger.Excel.Contracts.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.0;net472</TargetFrameworks>
-        <Version>1.4.0</Version>
+        <Version>1.4.1-preview</Version>
         <Description>
             Core abstractions and interfaces for Excel manipulation in .NET applications.
             Provides a common API for Excel operations that can be implemented by various

--- a/src/Linger.Excel.EPPlus/Linger.Excel.EPPlus.csproj
+++ b/src/Linger.Excel.EPPlus/Linger.Excel.EPPlus.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.0;net472</TargetFrameworks>
-    <Version>1.4.0</Version>
+    <Version>1.4.1-preview</Version>
     <Description>
       Excel operations implementation based on EPPlus library for the Linger.Excel framework.
       Provides high-performance Excel file reading, writing, styling, and manipulation

--- a/src/Linger.Excel.Npoi/Linger.Excel.Npoi.csproj
+++ b/src/Linger.Excel.Npoi/Linger.Excel.Npoi.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.0;net472</TargetFrameworks>
-        <Version>1.4.0</Version>
+        <Version>1.4.1-preview</Version>
         <Description>
             Excel operations implementation based on NPOI library for the Linger.Excel framework.
             Provides high-performance Excel file reading, writing, and manipulation capabilities

--- a/src/Linger.FileSystem.Ftp/Linger.FileSystem.Ftp.csproj
+++ b/src/Linger.FileSystem.Ftp/Linger.FileSystem.Ftp.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.0</TargetFrameworks>
-        <Version>1.4.0</Version>
+        <Version>1.4.1-preview</Version>
         <Description>
             An FTP implementation of the Linger FileSystem abstraction.
             Provides a robust and retry-capable FTP client for file operations using FluentFTP.

--- a/src/Linger.FileSystem.Sftp/Linger.FileSystem.Sftp.csproj
+++ b/src/Linger.FileSystem.Sftp/Linger.FileSystem.Sftp.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.0</TargetFrameworks>
-        <Version>1.4.0</Version>
+        <Version>1.4.1-preview</Version>
         <Description>
             An SFTP implementation of the Linger FileSystem abstraction.
             Provides a secure file transfer protocol client using SSH.NET for file operations.

--- a/src/Linger.FileSystem/Linger.FileSystem.csproj
+++ b/src/Linger.FileSystem/Linger.FileSystem.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.0</TargetFrameworks>
-        <Version>1.4.0</Version>        
+        <Version>1.4.1-preview</Version>        
 <Description>
             Unified file system abstraction library that provides a consistent interface for
             accessing different file systems (local, FTP, SFTP). Core library containing the 

--- a/src/Linger.HttpClient.Contracts/Linger.HttpClient.Contracts.csproj
+++ b/src/Linger.HttpClient.Contracts/Linger.HttpClient.Contracts.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.0;net472;</TargetFrameworks>
-    <Version>1.4.0</Version>
+    <Version>1.4.1-preview</Version>
     <Description>
       Contracts and interfaces for Linger HTTP client implementations.
       Provides a unified API for making typed HTTP requests with standardized error handling.

--- a/src/Linger.HttpClient.Standard/Linger.HttpClient.Standard.csproj
+++ b/src/Linger.HttpClient.Standard/Linger.HttpClient.Standard.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.0;net472;</TargetFrameworks>
-    <Version>1.4.0</Version>
+    <Version>1.4.1-preview</Version>
     <Description>
       A lightweight implementation of Linger.HttpClient.Contracts using standard .NET HttpClient.
       Provides robust HTTP request handling with automatic retries, timeout management, and typed response parsing.

--- a/src/Linger.Ldap.ActiveDirectory/Linger.Ldap.ActiveDirectory.csproj
+++ b/src/Linger.Ldap.ActiveDirectory/Linger.Ldap.ActiveDirectory.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.0;</TargetFrameworks>
-        <Version>1.4.0</Version>        
+        <Version>1.4.1-preview</Version>        
 <Description>
             Implementation of LDAP client functionality for Active Directory using System.DirectoryServices.
             Provides Windows-optimized AD connectivity with features for user authentication,

--- a/src/Linger.Ldap.Contracts/Linger.Ldap.Contracts.csproj
+++ b/src/Linger.Ldap.Contracts/Linger.Ldap.Contracts.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.0</TargetFrameworks>
-        <Version>1.4.0</Version>        
+        <Version>1.4.1-preview</Version>        
 <Description>
             Core abstractions and interfaces for LDAP directory operations in .NET applications.
             Defines data contracts, configuration models, and service interfaces for user authentication,

--- a/src/Linger.Ldap.Novell/Linger.Ldap.Novell.csproj
+++ b/src/Linger.Ldap.Novell/Linger.Ldap.Novell.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net10.0;net9.0;net8.0;</TargetFrameworks>
-        <Version>1.4.0</Version>        
+        <Version>1.4.1-preview</Version>        
 <Description>
             Implementation of LDAP client functionality using the Novell.Directory.Ldap provider.
             Provides cross-platform LDAP connectivity with features such as authentication, 

--- a/src/Linger.Results.AspNetCore/Linger.Results.AspNetCore.csproj
+++ b/src/Linger.Results.AspNetCore/Linger.Results.AspNetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0;</TargetFrameworks>
-    <Version>1.4.0</Version>
+    <Version>1.4.1-preview</Version>
 <Description>
       ASP.NET Core integration for Linger.Results library, providing extension methods to
       seamlessly convert Result objects to ActionResults with appropriate HTTP status codes.

--- a/src/Linger.Results/Linger.Results.csproj
+++ b/src/Linger.Results/Linger.Results.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.0;net472;</TargetFrameworks>
-    <Version>1.4.0</Version>
+    <Version>1.4.1-preview</Version>
     <Description>
       A modern functional-style operation result handling library for .NET applications.
       Provides a more elegant alternative to exception handling with strongly-typed Results

--- a/src/Linger.SharedKernel/Linger.SharedKernel.csproj
+++ b/src/Linger.SharedKernel/Linger.SharedKernel.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
       <TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.0;net472;</TargetFrameworks>
-      <Version>1.4.0</Version>      
+      <Version>1.4.1-preview</Version>      
 <Description>
           Core domain primitives and shared components for Linger applications.
           Provides base search models, pagination support, and essential building blocks

--- a/src/Linger/Extensions/Data/DataTableExtensions.cs
+++ b/src/Linger/Extensions/Data/DataTableExtensions.cs
@@ -881,7 +881,7 @@ public static class DataTableExtensions
 
                     if (value != DBNull.Value)
                     {
-                        SetPropertySafely(item, property, value);
+                        SetProperty(item, property, value);
                     }
                 }
 
@@ -904,7 +904,7 @@ public static class DataTableExtensions
 
                     if (value != DBNull.Value)
                     {
-                        SetPropertySafely(item, property, value);
+                        SetProperty(item, property, value);
                     }
                 }
 
@@ -946,28 +946,43 @@ public static class DataTableExtensions
     }
 
     /// <summary>
-    /// Safely sets a property value with type conversion and error handling.
+    /// 动态为属性赋值。类型不兼容、格式不匹配、只读属性或向不可空值类型赋 null 时，直接抛出异常。
     /// </summary>
-    /// <typeparam name="T">The target object type.</typeparam>
-    /// <param name="obj">The target object.</param>
-    /// <param name="property">The property to set.</param>
-    /// <param name="value">The value to set.</param>
-    private static void SetPropertySafely<T>(T obj, PropertyInfo property, object? value) where T : class
+    /// <exception cref="ArgumentNullException">当 property 为 null 时抛出</exception>
+    /// <exception cref="InvalidOperationException">当属性不可写时抛出</exception>
+    /// <exception cref="InvalidCastException">当类型转换或赋值失败时抛出</exception>
+    private static void SetProperty<T>(this T obj, PropertyInfo property, object? value) where T : class
     {
-        if (!property.CanWrite || value == DBNull.Value)
-            return;
+        ArgumentNullException.ThrowIfNull(property);
 
-        try
+        if (!property.CanWrite)
         {
-            if (Helper.TypeConverter.TryConvertTo(value, property.PropertyType, out var convertedValue))
+            throw new InvalidOperationException($"属性 {property.Name} 是只读的，无法赋值。");
+        }
+
+        if (value is null || value is DBNull)
+        {
+            if (property.PropertyType.IsValueType && Nullable.GetUnderlyingType(property.PropertyType) is null)
             {
-                property.SetValue(obj, convertedValue);
+                throw new InvalidCastException($"无法将 null 赋值给不可空的值类型属性: '{property.DeclaringType?.Name}.{property.Name}'。");
             }
+
+            property.SetValue(obj, null);
+            return;
         }
-        catch
+
+        if (!Helper.TypeConverter.TryConvertTo(value, property.PropertyType, out var convertedValue))
         {
-            // Silent fail for incompatible conversions to maintain compatibility
-            // In production, you might want to log this or use a different strategy
+            throw new InvalidCastException(
+                $"[核心转换失败] 无法将输入值 '{value}' (类型: {value.GetType().Name}) 转换为属性 '{property.Name}' 所需的目标类型 {property.PropertyType.Name}。 " +
+                $"当前系统的运行时 Culture 是: '{CultureInfo.CurrentCulture.Name}'。");
         }
+
+        if (convertedValue is null && property.PropertyType.IsValueType && Nullable.GetUnderlyingType(property.PropertyType) is null)
+        {
+            throw new InvalidCastException($"转换器发生异常：无法将转换后的 null 赋值给不可空值类型 '{property.Name}'。");
+        }
+
+        property.SetValue(obj, convertedValue);
     }
 }

--- a/src/Linger/Helper/TypeConverter.cs
+++ b/src/Linger/Helper/TypeConverter.cs
@@ -306,13 +306,34 @@ public static class TypeConverter
                 result = dt;
                 return true;
             }
-
-            if (DateTime.TryParse(value.ToString(), CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateResult))
+            string strValue = value.ToString()?.Trim() ?? string.Empty;
+            // 策略 1：使用固定区域性解析（兼容 en-US、标准 ISO、以及无歧义格式）
+            if (DateTime.TryParse(strValue, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateResult))
             {
                 result = dateResult;
                 return true;
             }
-
+            // 策略 2：【针对 zh-CN 生产环境修复】尝试用当前线程 Culture 解析（兼容带有"上午/下午"、"年/月/日"等本地格式）
+            if (DateTime.TryParse(strValue, CultureInfo.CurrentCulture, DateTimeStyles.None, out dateResult))
+            {
+                result = dateResult;
+                return true;
+            }
+            // 策略 3：常见工业格式多模版精确匹配兜底
+            string[] extraFormats = new[]
+            {
+                "M/d/yyyy h:mm:ss tt",
+                "yyyy/M/d H:mm:ss",
+                "yyyy/M/d h:mm:ss tt",
+                "yyyy-MM-dd HH:mm:ss",
+                "yyyy/MM/dd HH:mm:ss"
+            };
+            if (DateTime.TryParseExact(strValue, extraFormats, CultureInfo.InvariantCulture, DateTimeStyles.None, out dateResult))
+            {
+                result = dateResult;
+                return true;
+            }
+            // 彻底失败：不要改变 result，直接返回 false，交给外层决定是阻断还是记录
             result = null;
             return false;
         }

--- a/src/Linger/Linger.csproj
+++ b/src/Linger/Linger.csproj
@@ -8,7 +8,7 @@
             date/time helpers, file system operations, collection extensions, and various helper classes for everyday development tasks.
             Supports multiple .NET frameworks including .NET Standard 2.0, .NET Framework 4.7.2, .NET 8.0, .NET 9.0, and .NET 10.0.
         </Description>
-        <Version>1.4.0</Version>
+        <Version>1.4.1-preview</Version>
 <Deterministic>true</Deterministic>
     </PropertyGroup>
 

--- a/tests/Linger.UnitTests/Extensions/Data/DataTableExtensionsTests.cs
+++ b/tests/Linger.UnitTests/Extensions/Data/DataTableExtensionsTests.cs
@@ -112,6 +112,18 @@ public partial class DataTableExtensionsTests
     }
 
     [Fact]
+    public void ToList_WithInvalidDateTimeValue_ThrowsInvalidCastException()
+    {
+        var table = new DataTable();
+        table.Columns.Add("DateTime", typeof(string));
+        table.Rows.Add("not a date");
+
+        var exception = Assert.Throws<InvalidCastException>(() => table.ToList<TestClass2>());
+
+        Assert.Contains("DateTime", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ToList_WithMapperAndParameterizedConstructor_ReturnsListOfObjects()
     {
         DataTable? table = CreateTestDataTable();

--- a/tests/Linger.UnitTests/Helper/TypeConverterTests.cs
+++ b/tests/Linger.UnitTests/Helper/TypeConverterTests.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Linger.UnitTests.Helper;
 
 using Linger.Helper;
@@ -379,6 +381,26 @@ public class TypeConverterTests
         var success = TypeConverter.TryConvertTo("2024-01-15", typeof(DateTime), out var result);
         Assert.True(success);
         Assert.Equal(new DateTime(2024, 1, 15), result);
+    }
+
+    [Fact]
+    public void TryConvertTo_StringToDateTime_WithZhCnCulture_ReturnsTrueAndValue()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("zh-CN");
+
+            var success = TypeConverter.TryConvertTo("2024/1/15 下午 3:04:05", typeof(DateTime), out var result);
+
+            Assert.True(success);
+            Assert.Equal(new DateTime(2024, 1, 15, 15, 4, 5), result);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
     }
 
     [Fact]


### PR DESCRIPTION
Update to 1.4.1-preview; improve type conversion & tests

Replaced SetPropertySafely with SetProperty in DataTableExtensions, now throwing on type errors and nulls for non-nullable types. Enhanced DateTime parsing in TypeConverter to support current culture and multiple formats. Added tests for invalid DateTime conversion and zh-CN culture handling. Updated all project files to version 1.4.1-preview.